### PR TITLE
Fix TF linters wrong directory

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Init linter
         working-directory: ${{ env.TF_DIR }}
-        run: tflint --init --chdir=infra
+        run: tflint --init
 
       - name: Run linter
         working-directory: ${{ env.TF_DIR }}
-        run: tflint --chdir=infra
+        run: tflint --recursive --no-color

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -3,7 +3,8 @@ on:
   pull_request:
 
 env:
-  FOO: "BAR"
+  TF_DIR: "infra"
+
 
 jobs:
   tfsyntax:
@@ -15,11 +16,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run terraform validate
+        working-directory: ${{ env.TF_DIR }}
         run: |
           terraform init -backend=false
           terraform validate -no-color
 
       - name: Run terraform fmt
+        working-directory: ${{ env.TF_DIR }}
         run: |
           terraform fmt -check -diff -recursive -no-color  
 
@@ -35,7 +38,9 @@ jobs:
         run: rm -rf infra/.tflint.d
 
       - name: Init linter
+        working-directory: ${{ env.TF_DIR }}
         run: tflint --init --chdir=infra
 
       - name: Run linter
+        working-directory: ${{ env.TF_DIR }}
         run: tflint --chdir=infra


### PR DESCRIPTION
This PR refines the GitHub Actions Terraform linter workflow. Key changes include:

Environment Variable Addition: Added TF_DIR set to infra, specifying the Terraform files directory.

Workflow Step Updates: Updated Run terraform validate and Run terraform fmt steps to operate within TF_DIR.

TFLint Improvements: Streamlined TFLint initialization and execution, now using TF_DIR and added recursive and no-color options.