### PR TITLE
Lambda config update: logs

### DIFF
--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -13,6 +13,16 @@ resource "aws_lambda_function" "this" {
   environment {
     variables = { for item in var.function_ssm_parameter_names : upper(replace(item, "-", "_")) => aws_ssm_parameter.function_ssm_parameters[item].name }
   }
+  logging_config {
+    application_log_level = "INFO"
+    log_format            = "JSON"
+    system_log_level      = "INFO"
+    log_group             = aws_cloudwatch_log_group.this.name
+  }
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role.this,
+  ]
 }
 
 resource "aws_ssm_parameter" "function_ssm_parameters" {


### PR DESCRIPTION
This merge request introduces the following changes to the `aws_lambda_function` resource in the `infra/modules/lambda/main.tf` file:

1. Added a `logging_config` block to the Lambda function configuration. This block sets the application and system log levels to "INFO", specifies the log format as "JSON", and associates the function with a CloudWatch log group.

2. Added a `depends_on` block to the Lambda function configuration. This block specifies that the function depends on the `aws_cloudwatch_log_group` and `aws_iam_role` resources. This ensures that these resources are created before the Lambda function.

These changes aim to improve the observability of the Lambda function by enabling detailed logging and ensuring the correct order of resource creation.